### PR TITLE
Fix manifest icon paths for IPFS deployment

### DIFF
--- a/app/assets/images/favicons/site.webmanifest
+++ b/app/assets/images/favicons/site.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "",
     "icons": [
         {
-            "src": "https://augur.guide/assets/images/favicons/android-chrome-192x192.png",
+            "src": "./android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "https://augur.guide/assets/images/favicons/android-chrome-384x384.png",
+            "src": "./android-chrome-384x384.png",
             "sizes": "384x384",
             "type": "image/png"
         }


### PR DESCRIPTION
## Description
Fixed 404 errors for manifest icons by changing absolute URLs to relative paths.

## Issue
Fixes #9

## Testing
- Verified that icons load correctly when accessing via IPFS

### Before
`v1.0.0`: https://bafybeibaochkck7lhp3qobqnysljhcsjswnkgvmhb7f7i6y6zadru4kwhq.ipfs.nftstorage.link/
![image](https://github.com/user-attachments/assets/239b0f10-c8db-47a5-9c00-903e705f03a1)

### After
https://bafybeiddkl6pdwytbwcxmo4vfz2z73fr7c3kuzkepk7yq7xwglwzvfumui.ipfs.nftstorage.link/
![image](https://github.com/user-attachments/assets/1d19384d-e470-443d-88f5-9eac4cb0a906)

